### PR TITLE
feat: add user display name to authorized users list command

### DIFF
--- a/Thunder/bot/plugins/admin.py
+++ b/Thunder/bot/plugins/admin.py
@@ -236,10 +236,14 @@ async def list_authorized_command(client: Client, message: Message):
     for i, user in enumerate(users, 1):
         display_name = "Unknown"
         try:
-            tg_user = await client.get_users(user['user_id'])
+            try:
+                tg_user = await client.get_users(user['user_id'])
+            except FloodWait as e:
+                await asyncio.sleep(e.value)
+                tg_user = await client.get_users(user['user_id'])
             display_name = f"@{tg_user.username}" if tg_user.username else tg_user.first_name or "Unknown"
         except Exception:
-            pass
+            logger.error("Failed to fetch tg_user for user_id=%s", user['user_id'], exc_info=True)
 
         text += MSG_AUTH_USER_INFO.format(
             i=i,

--- a/Thunder/bot/plugins/admin.py
+++ b/Thunder/bot/plugins/admin.py
@@ -234,8 +234,17 @@ async def list_authorized_command(client: Client, message: Message):
     
     text = MSG_ADMIN_AUTH_LIST_HEADER
     for i, user in enumerate(users, 1):
+        display_name = "Unknown"
+        try:
+            tg_user = await client.get_users(user['user_id'])
+            display_name = f"@{tg_user.username}" if tg_user.username else tg_user.first_name or "Unknown"
+        except Exception:
+            pass
+
         text += MSG_AUTH_USER_INFO.format(
-            i=i, user_id=user['user_id'],
+            i=i,
+            display_name=display_name,
+            user_id=user['user_id'],
             authorized_by=user['authorized_by'],
             auth_time=user['authorized_at']
         )

--- a/Thunder/utils/messages.py
+++ b/Thunder/utils/messages.py
@@ -88,7 +88,8 @@ MSG_DEAUTHORIZE_SUCCESS = (
 MSG_TOKEN_ACTIVATED = "✅ Token successfully activated!\n\n⏳ This token is valid for {duration_hours} hours."
 MSG_TOKEN_INVALID = "🚫 **Expired or Invalid Token.** Please click the button below to activate your access token."
 MSG_NO_AUTH_USERS = "ℹ️ **No Authorized Users Found:** The list is currently empty."
-MSG_AUTH_USER_INFO = """{i}. 👤 User ID: `{user_id}`
+MSG_AUTH_USER_INFO = """{i}. 👤: {display_name}
+   • User ID: `{user_id}`
    • Authorized by: `{authorized_by}`
    • Date: `{auth_time}`\n\n"""
 MSG_ADMIN_AUTH_LIST_HEADER = "🔐 **Authorized Users List**\n\n"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Authorized users list now shows a display name (Telegram username when available, otherwise first name, or "Unknown") for clearer identification.
  * Authorized user entries formatted as a multi-line bulleted layout, improving readability of user ID, who authorized them, and authorization time.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fyaz05/FileToLink/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->